### PR TITLE
MSSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,3 @@ db-scripts
 If you are running the scrips inside an ec2 instance, make sure you configure its security group and inbound rules to allow for port connectivity.
 
 SQL Server requires a machine with at least 2GB RAM.
-
-Note that the root password for the SQL Server database is `Dev12345` rather than `Dev1234` due to an 8 character minimum.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ db-scripts
 |       ├── create_tables.sql
 |       ├── fill_tables.sql
 |       └── tidal_setup.sql
+├── mssql-2019
+|   ├── docker-compose.yml
+|   └── sql
+|       ├── create_tables.sql
+|       ├── fill_tables.sql
+|       └── tidal_setup.sql
 ├── ...more to come
 
 ```
@@ -43,3 +49,7 @@ db-scripts
 
 ### Troubleshooting
 If you are running the scrips inside an ec2 instance, make sure you configure its security group and inbound rules to allow for port connectivity.
+
+SQL Server requires a machine with at least 2GB RAM.
+
+Note that the root password for the SQL Server database is `Dev12345` rather than `Dev1234` due to an 8 character minimum.

--- a/mssql-2019/docker-compose.yml
+++ b/mssql-2019/docker-compose.yml
@@ -26,6 +26,7 @@ services:
           is_up=$$?
           sleep 5 
         done
+
         # Run the SQL scripts in order
         /opt/mssql-tools/bin/sqlcmd -U SA -P $$SA_PASSWORD -l 30 -e -i /scripts/create_tables.sql
         /opt/mssql-tools/bin/sqlcmd -U SA -P $$SA_PASSWORD -l 30 -e -i /scripts/fill_tables.sql

--- a/mssql-2019/docker-compose.yml
+++ b/mssql-2019/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.7'
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    environment: 
+      - SA_PASSWORD=Dev12345
+      - ACCEPT_EULA=Y
+    ports:
+      - 1433:1433
+    volumes:
+     - ./sql:/scripts/
+    command:
+      - /bin/bash
+      - -c 
+      - |
+        # Launch mssql and send to background
+        /opt/mssql/bin/sqlservr &
+        
+        # Wait for it to be available
+        echo "Waiting for MS SQL to be available ⏳"
+        /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -h-1 -V1 -U sa -P $$SA_PASSWORD -Q "SET NOCOUNT ON SELECT \"YAY WE ARE UP\" , @@servername"
+        is_up=$$?
+        while [ $$is_up -ne 0 ] ; do 
+          echo -e $$(date) 
+          /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -h-1 -V1 -U sa -P $$SA_PASSWORD -Q "SET NOCOUNT ON SELECT \"YAY WE ARE UP\" , @@servername"
+          is_up=$$?
+          sleep 5 
+        done
+        # Run the SQL scripts in order
+        /opt/mssql-tools/bin/sqlcmd -U SA -P $$SA_PASSWORD -l 30 -e -i /scripts/create_tables.sql
+        /opt/mssql-tools/bin/sqlcmd -U SA -P $$SA_PASSWORD -l 30 -e -i /scripts/fill_tables.sql
+        /opt/mssql-tools/bin/sqlcmd -U SA -P $$SA_PASSWORD -l 30 -e -i /scripts/tidal_setup.sql
+        # So that the container doesn't shut down, sleep this thread
+        sleep infinity

--- a/mssql-2019/sql/create_tables.sql
+++ b/mssql-2019/sql/create_tables.sql
@@ -1,0 +1,107 @@
+CREATE DATABASE DemoMSSQLDatabase
+GO
+
+Use DemoMSSQLDatabase
+GO
+
+
+-- Creation of product table
+IF OBJECT_ID('product', 'U') IS NULL
+CREATE TABLE product (
+  product_id INT NOT NULL,
+  name varchar(250) NOT NULL,
+  PRIMARY KEY (product_id)
+);
+GO
+
+-- Creation of country table
+IF OBJECT_ID('country', 'U') IS NULL
+CREATE TABLE country (
+  country_id INT NOT NULL,
+  country_name varchar(450) NOT NULL,
+  PRIMARY KEY (country_id)
+);
+GO
+
+-- Creation of city table
+IF OBJECT_ID('city', 'U') IS NULL
+CREATE TABLE city (
+  city_id INT NOT NULL,
+  city_name varchar(450) NOT NULL,
+  country_id INT NOT NULL,
+  PRIMARY KEY (city_id),
+  CONSTRAINT fk_country
+      FOREIGN KEY(country_id) 
+	  REFERENCES country(country_id)
+);
+GO
+
+-- Creation of store table
+IF OBJECT_ID('store', 'U') IS NULL
+CREATE TABLE store (
+  store_id INT NOT NULL,
+  name varchar(250) NOT NULL,
+  city_id INT NOT NULL,
+  PRIMARY KEY (store_id),
+  CONSTRAINT fk_city
+      FOREIGN KEY(city_id) 
+	  REFERENCES city(city_id)
+);
+GO
+
+-- Creation of user table
+IF OBJECT_ID('users', 'U') IS NULL
+CREATE TABLE users (
+  user_id INT NOT NULL,
+  name varchar(250) NOT NULL,
+  PRIMARY KEY (user_id)
+);
+GO
+
+-- Creation of status_name table
+IF OBJECT_ID('status_name', 'U') IS NULL
+CREATE TABLE status_name (
+  status_name_id INT NOT NULL,
+  status_name varchar(450) NOT NULL,
+  PRIMARY KEY (status_name_id)
+);
+GO
+
+-- Creation of sale table
+IF OBJECT_ID('sale', 'U') IS NULL
+CREATE TABLE sale (
+  sale_id varchar(200) NOT NULL,
+  amount DECIMAL(20,3) NOT NULL,
+  date_sale DATE NOT NULL,
+  product_id INT NOT NULL,
+  user_id INT NOT NULL,
+  store_id INT NOT NULL, 
+  PRIMARY KEY (sale_id),
+  CONSTRAINT fk_product
+      FOREIGN KEY(product_id) 
+	  REFERENCES product(product_id),
+  CONSTRAINT fk_user
+      FOREIGN KEY(user_id) 
+	  REFERENCES users(user_id),
+  CONSTRAINT fk_store
+      FOREIGN KEY(store_id) 
+	  REFERENCES store(store_id)	  
+);
+GO
+
+-- Creation of order_status table
+IF OBJECT_ID('order_status', 'U') IS NULL
+CREATE TABLE order_status (
+  order_status_id varchar(200) NOT NULL,
+  update_at DATE NOT NULL,
+  sale_id varchar(200) NOT NULL,
+  status_name_id INT NOT NULL,
+  PRIMARY KEY (order_status_id),
+  CONSTRAINT fk_sale
+      FOREIGN KEY(sale_id) 
+	  REFERENCES sale(sale_id),
+  CONSTRAINT fk_status_name
+      FOREIGN KEY(status_name_id) 
+	  REFERENCES status_name(status_name_id)  
+);
+GO

--- a/mssql-2019/sql/fill_tables.sql
+++ b/mssql-2019/sql/fill_tables.sql
@@ -1,0 +1,109 @@
+USE DemoMSSQLDatabase;
+GO
+
+INSERT INTO product (
+	product_id,
+	name
+)
+VALUES 
+	(1, 'Guitar'),
+	(2, 'Piano'),
+	(3, 'Drum'),
+	(4, 'Bass');
+	
+
+
+INSERT INTO country (
+	country_id,
+	country_name
+)
+VALUES 
+	(1, 'Canada'),
+	(2, 'Australia'),
+	(3, 'United States'),
+	(4, 'Colombia');
+
+
+
+INSERT INTO city (
+	city_id,
+	city_name,
+	country_id
+)
+VALUES 
+	(1, 'Toronto', 1),
+	(2, 'Halifax', 1),
+	(3, 'Vancouver', 1),
+	(4, 'sidney', 2),
+	(5, 'melbourne', 2),
+	(6, 'Bogota', 4);
+
+
+
+
+INSERT INTO store (
+	store_id,
+	name,
+	city_id	
+)
+VALUES 
+	(1, 'Toronto store', 1),
+	(2, 'Halifax store', 1),
+	(3, 'Vancouver store', 1),
+	(4, 'sidney store', 2),
+	(5, 'melbourne store', 2),
+	(6, 'Bogota store', 4);
+
+
+
+
+INSERT INTO users (
+	user_id,
+	name	
+)
+VALUES 
+	(1, 'Freddy Mercury'),
+	(2, 'Brian May'),
+	(3, 'John Deacon'),
+	(4, 'Roger Taylor');
+
+
+INSERT INTO status_name (
+	status_name_id,
+	status_name
+)
+VALUES 
+	(1, 'Done'),
+	(2, 'Unknown'),
+	(3, 'Pending'),
+	(4, 'Removed');
+
+
+
+INSERT INTO sale (
+	sale_id,
+	amount,
+	date_sale,
+	product_id,
+	user_id,
+	store_id
+)
+VALUES 
+	("283e046b-7e8a-4495-a159-d23b20f02cad", 222, "20220105", 3, 1, 6 ),
+	("c48bc5d2-9d5b-4b39-91e3-cdf3147e6502", 502, "20220211", 2, 1, 6 ),
+	("12b3aebe-7db6-4e54-a9ce-95de95b97ae3", 31, "20220212", 1, 1, 6 ),
+	("b3ec5a17-f3c0-45fc-a97b-7453f1c8ecb9", 106, "20220112", 4, 1, 6 );	
+
+
+
+INSERT INTO order_status (
+	order_status_id,
+	update_at,
+	sale_id,
+	status_name_id	
+)
+VALUES 
+	("813b254f-3091-4ad4-9fca-69ce14a9c83f", "20220222", "283e046b-7e8a-4495-a159-d23b20f02cad", 3),
+	("59efc756-669b-4e60-bc58-3ae49c8166ec", "20220222", "c48bc5d2-9d5b-4b39-91e3-cdf3147e6502", 2),
+	("dfbd7ffe-1ca7-410c-bef3-19ca5b74efb5", "20220222", "12b3aebe-7db6-4e54-a9ce-95de95b97ae3", 1),
+	("353a26ee-be2c-40b2-b203-632ada77ffdf", "20220222", "b3ec5a17-f3c0-45fc-a97b-7453f1c8ecb9", 4);	

--- a/mssql-2019/sql/tidal_setup.sql
+++ b/mssql-2019/sql/tidal_setup.sql
@@ -1,0 +1,395 @@
+declare @loginName varchar (100) 
+declare @password varchar (100)
+declare @SqlStatement2 nvarchar(4000)
+declare @SqlStatement3 nvarchar(4000)
+declare @ver int
+
+set @loginName = 'tidal'
+set @password  = 'Dev1234'
+select @ver = left(cast(SERVERPROPERTY('productversion') as varchar(50)), charindex('.', cast(SERVERPROPERTY('productversion') as varchar(50)))-1)
+
+declare @dbname varchar (100) 
+
+if @ver <= 8 --For SQL 2000 and lower
+BEGIN
+	DECLARE db_cursor CURSOR FOR
+	SELECT name
+	FROM master.dbo.sysdatabases
+	where DATABASEPROPERTYEX(name, 'Status') = 'ONLINE'
+END
+
+if @ver > 8 --For SQL 2005 and higher
+BEGIN
+	DECLARE db_cursor CURSOR FOR
+	SELECT name
+	FROM master.sys.databases
+	WHERE name NOT IN ('tempdb')
+	 and state_desc = 'online'
+	 and is_read_only =0
+END
+
+--Creating SQL login and DB users in every database on the instance
+
+OPEN db_cursor
+FETCH NEXT FROM db_cursor INTO @dbname
+WHILE @@FETCH_STATUS = 0 
+BEGIN 
+	declare @SqlStatement nvarchar(4000)
+	Set @SqlStatement =
+	CASE WHEN @ver <= 8 --For SQL 2000 only
+		THEN'IF NOT EXISTS 
+			(SELECT name  
+				FROM master.dbo.syslogins
+				WHERE name = '''+@loginName +''') 
+			EXEC sp_addlogin @loginame=''' + @loginName + ''', @passwd='''+ @password +''', @defdb=[master]
+			use [' + @dbname + ']; 
+			IF NOT EXISTS (SELECT [name]
+						FROM [dbo].[sysusers]
+						WHERE [islogin] = 1 AND [isntname] = 0 AND [name] = ''' + @loginName +''')
+						exec sp_adduser @loginame=''' + @loginName + ''', @name_in_db='''+@loginName +''';'
+		ELSE
+			'IF NOT EXISTS 
+			(SELECT name  
+				FROM master.sys.server_principals
+				WHERE name = '''+@loginName +''') 
+				CREATE LOGIN ['+@loginName +'] WITH PASSWORD = '''+ @password +''' ,DEFAULT_DATABASE=[master], CHECK_EXPIRATION=OFF, CHECK_POLICY=OFF
+			use [' + @dbname + ']; 
+			IF NOT EXISTS (SELECT [name]
+						FROM [sys].[database_principals]
+						WHERE [type] = N''S'' AND [name] = ''' + @loginName +''') 
+			CREATE USER ['+ @loginName +'] FOR LOGIN ['+@loginName +'] ;'
+	END
+	--print @SqlStatement
+	EXEC sp_executesql @SqlStatement
+	FETCH NEXT FROM db_cursor INTO @dbname
+END
+
+--Granting specific permissions
+
+if @ver <= 8 --For SQL 2000 and lower
+BEGIN
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysaltfiles TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+  
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.syscolumns TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysobjects TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.syscomments TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysprocesses TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.systypes TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.syslogins TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysobjects TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysservers TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysfilegroups TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysindexes TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysforeignkeys TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysconfigures TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysfiles TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysdatabases TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysdevices TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysconstraints TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.syscolumns TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysprocesses TO ['+@loginName +'];'
+	EXEC sp_executesql @SqlStatement2
+
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.syslocks TO ['+@loginName +'];'
+	EXEC sp_executesql @SqlStatement2
+
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON dbo.sysperfinfo TO ['+@loginName +'];'
+	EXEC sp_executesql @SqlStatement2
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.restorehistory TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysjobschedules TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysjobsteps TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.log_shipping_primaries TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.log_shipping_secondaries TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysjobs TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysalerts TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysjobschedules TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysjobs TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.backupset TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysalerts  TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysjobs TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysdbmaintplans TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysdbmaintplan_jobs TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 = 'USE MSDB; GRANT SELECT ON dbo.sysdtspackages TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+END
+
+if @ver > 8 --For SQL 2005 and higher
+BEGIN
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.master_files TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+  
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.columns TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.objects TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.sql_modules TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.sysprocesses TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.server_triggers TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.master_files TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.partitions TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.types TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.server_principals TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.syslogins TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.server_permissions TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.triggers TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.objects TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.servers TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.symmetric_keys TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.synonyms TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.dm_os_cluster_nodes TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+  
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.fulltext_index_columns TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.partition_schemes  TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+  
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.partition_functions TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.tables TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.event_notifications TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.data_spaces TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON master.sys.indexes TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON master.sys.foreign_keys TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.computed_columns TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.configurations TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.credentials TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.database_files TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.filegroups TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.database_mirroring TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.databases TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.assembly_modules TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.asymmetric_keys TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.backup_devices TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.certificates TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.check_constraints TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.columns TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON sys.default_constraints TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement2
+ 
+	Set @SqlStatement2 = 'USE MASTER; GRANT VIEW SERVER STATE TO ['+@loginName +'];'
+	EXEC sp_executesql @SqlStatement2
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.log_shipping_secondary_databases TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.restorehistory TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysjobschedules TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysjobsteps TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.log_shipping_primary_databases TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.log_shipping_secondary_databases TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysjobs TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysalerts TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysjobschedules TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysjobs TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.backupset TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.log_shipping_primary_databases TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysalerts  TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysjobs TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysmaintplan_plans TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+
+	Set @SqlStatement3 ='USE MSDB; GRANT SELECT ON dbo.sysmaintplan_subplans TO [' + @loginName + '];'
+	EXEC sp_executesql @SqlStatement3
+END
+
+--For all versions
+Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON INFORMATION_SCHEMA.TABLES TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+
+Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON INFORMATION_SCHEMA.COLUMNS  TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+ 
+Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON INFORMATION_SCHEMA.PARAMETERS TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+
+Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON information_schema.routines TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+ 
+Set @SqlStatement2 = 'USE MASTER; GRANT SELECT ON INFORMATION_SCHEMA.VIEWS TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+ 
+Set @SqlStatement2 = 'USE MASTER; IF OBJECT_ID (N''sys.server_event_sessions'') IS NOT NULL GRANT SELECT ON sys.server_event_sessions TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+ 
+Set @SqlStatement2 = 'USE MASTER; IF OBJECT_ID (N''sys.resource_governor_configuration'') IS NOT NULL GRANT SELECT ON sys.resource_governor_configuration TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+ 
+Set @SqlStatement2 = 'USE MASTER; IF OBJECT_ID (N''sys.sequences'') IS NOT NULL GRANT SELECT ON sys.sequences TO [' + @loginName +'];'
+EXEC sp_executesql @SqlStatement2
+
+Set @SqlStatement2 = 'USE MASTER; IF OBJECT_ID (N''sys.server_audits'') IS NOT NULL GRANT SELECT ON sys.server_audits TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+
+Set @SqlStatement2 = 'USE MASTER; IF OBJECT_ID (N''sys.hash_indexes'') IS NOT NULL GRANT SELECT ON sys.hash_indexes TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+  
+Set @SqlStatement2 = 'USE MASTER; IF OBJECT_ID (N''sys.masked_columns'') IS NOT NULL GRANT SELECT ON sys.masked_columns TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+ 
+Set @SqlStatement2 = 'USE MASTER; IF OBJECT_ID (N''sys.filetables'') IS NOT NULL GRANT SELECT ON sys.filetables TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+ 
+Set @SqlStatement2 = 'USE MASTER; IF OBJECT_ID (N''sys.fn_db_backup_file_snapshots'') IS NOT NULL GRANT SELECT ON sys.fn_db_backup_file_snapshots TO [' + @loginName + '];'
+EXEC sp_executesql @SqlStatement2
+
+CLOSE db_cursor
+deallocate db_cursor


### PR DESCRIPTION
Note: This is a re-do of an earlier closed PR, with more generic demo data.

Adds an MSSQL (SQL Server) demo database. This database can be created with exactly the same command as the others in this repo, by navigating to its directory and running `docker-compose up -d`.

The database is populated with the similar demo data found in the other databases, with slight updates to conform with TSQL.