### PR TITLE
Doc connection to MSSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ db-scripts
 
 3. That is it. The Database will be up and running and ready to be analyzed.
 
+### Connecting
+
+#### MSSQL-2019
+
+Connect as root user
+`sqlcmd -S "<public-ipv4-dns>,1433" -U SA -P "Dev12345"`
+
+Connect as Tidal user
+`sqlcmd -S "<public-ipv4-dns>,1433" -U Tidal -P "Dev1234"`
 
 ### Troubleshooting
 If you are running the scrips inside an ec2 instance, make sure you configure its security group and inbound rules to allow for port connectivity.


### PR DESCRIPTION
This adds a new section to the README 'connection', where we can doc how to connect to each database using that databases cli tool. The info here can then be applied to whatever database connection tool the user would like to use, such as VSCode, DBeaver, etc. 

This is an example of how to connect using DBeaver:
![image](https://user-images.githubusercontent.com/43866616/158928092-db0fd675-55c2-4343-8aa7-3681bdf22a61.png)

Connecting as the root account will allow you to perform SELECT (and all other) operations on tables. Connecting as the user `Tidal` created by the `tidal_setup.sql` script will allow you to connect to the DB, but you can't perform any operations on the tables. It's unclear if this is intentional - if so it's an issue with the setup script not the MSSQL database and should be addressed in a future PR.