### PR TITLE
Add Databases.yaml.example

### DIFF
--- a/Databases.yaml.example
+++ b/Databases.yaml.example
@@ -1,0 +1,29 @@
+################################################################################################################################
+# This file contains the configuration settings for each one of the supported engines (Oracle, MS SQL, MySQL and Postgres).    #
+# Adjust the section that matches your database(s). You can delete the rest or comment it out.                                 #
+# For more information, please visit the Tidal Migrations guides.                                                              #
+# https://guides.tidalmg.com/analyze-database.html#getting-started                                                             #
+################################################################################################################################
+
+databases:
+    ########  MS SQL  ########
+    - id: 1 ## <-- Replace with your demo database's Tidal ID
+      name: "Airbnb Product database" ## <-- Replace with your demo database's Tidal name
+      engine: SQL Server
+      version: 15.0.4198.2
+      host: ""
+      port: 1433
+      db_name: "DemoMSSQLDatabase"
+      user: "tidal"
+      password: "Dev12345"
+      
+    #######  Postgres  ########
+    - id: 1 ## <-- Replace with your demo database's Tidal ID
+      name: "Airbnb Product database" ## <-- Replace with your demo database's Tidal name
+      engine: PostgreSQL
+      version: 10.5
+      host: ""
+      port: 5432
+      db_name: "postgres"
+      user: "tidal"
+      password: "Dev12345"

--- a/Databases.yaml.example
+++ b/Databases.yaml.example
@@ -20,3 +20,15 @@ databases:
       db_name: "postgres"
       user: "tidal"
       password: "Dev12345"
+    
+    ########  MySQL  ########
+    - id: 1 ## <-- Replace with your demo database's Tidal ID
+      name: "Airbnb Product database" ## <-- Replace with your demo database's Tidal name
+      engine: MySQL
+      version: 8.0
+      host: "ec2-18-142-50-121.ap-southeast-1.compute.amazonaws.com"
+      port: 3306
+      db_name: "tidal_db"
+      user: "tidal"
+      password: "Dev12345"
+

--- a/Databases.yaml.example
+++ b/Databases.yaml.example
@@ -1,10 +1,3 @@
-################################################################################################################################
-# This file contains the configuration settings for each one of the supported engines (Oracle, MS SQL, MySQL and Postgres).    #
-# Adjust the section that matches your database(s). You can delete the rest or comment it out.                                 #
-# For more information, please visit the Tidal Migrations guides.                                                              #
-# https://guides.tidalmg.com/analyze-database.html#getting-started                                                             #
-################################################################################################################################
-
 databases:
     ########  MS SQL  ########
     - id: 1 ## <-- Replace with your demo database's Tidal ID

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ db-scripts
 
 Simply run `docker-compose up -d` and the databases will be up and running and ready to be analyzed.
 
+You can find sample values for your Tidal Tools `Databases.yaml` file in this repo, in `./Databases.yaml.example`.
+
 ### Connecting
 
 #### MSSQL-2019

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
           - ./mysql-8/sql/tidal_setup.sql:/docker-entrypoint-initdb.d/tidal_setup.sql
     
     mssql:
-      image: mcr.microsoft.com/mssql/server:2019-latest
+      image: mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
       environment: 
         - SA_PASSWORD=Dev12345
         - ACCEPT_EULA=Y


### PR DESCRIPTION
Added a Databases.yaml.example file, with the values needed to connect to our testing databases. 

Aim is to save from digging around for versions and default database names and so on. Also updated the MSSQL script to always pull the same image (rather than the latest) so that the version number remains consistent.

Includes details for all dbs except oracle as we don't have that one up yet.